### PR TITLE
Removed the ipvolume requirement 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 sympy
 pandas
 matplotlib
-ipyvolume
 pydy
 pytest
 versioneer

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
+    extras_require={'plot': ['ipvolume', 'ipywidgets']}
     python_requires='>=3.5',
 
     install_requires=requirements,


### PR DESCRIPTION
and added it as an extra_require, which gets installed with pip install rigidbodysimulator[plot]